### PR TITLE
build: release beta5

### DIFF
--- a/content/export-templates.md
+++ b/content/export-templates.md
@@ -7,7 +7,12 @@ draft: false
 # Export Templates
 
 mpvQC uses the [Jinja template](https://jinja.palletsprojects.com/en/3.1.x/) engine to customize how QC reports are
-exported. This allows you to control the format and structure of your exported documents.
+exported: templates control the format and structure of the documents written by the export menu.
+
+Templates are made for human-readable output. If you want to feed QC data into scripts or other tooling, you don't
+need a template: mpvQC saves QC documents in a
+[versioned JSON format](https://github.com/mpvqc/mpvQC/tree/main/docs/document-format) with a JSON Schema per
+version, designed exactly for that.
 
 ## Getting Started
 
@@ -16,7 +21,7 @@ exported. This allows you to control the format and structure of your exported d
 3. Edit the template file using any text editor
 4. Restart mpvQC to load the new template
 
-Once loaded, your custom template will appear as a new export option in the File menu.
+Once loaded, your custom template appears as a new entry under **File → Export QC Document**.
 
 ## Template Reference
 
@@ -28,7 +33,7 @@ In addition to standard Jinja expressions, mpvQC provides the following properti
 |--------------------------|--------------|---------------------------------------------------------------------|
 | **Report Metadata**      |              |                                                                     |
 | `write_date`             | `bool`       | Whether to include the export date/time                             |
-| `date`                   | `str`        | Current date/time formatted according to user's locale (LongFormat) |
+| `date`                   | `str`        | Current date/time as `yyyy-MM-dd HH:mm`                             |
 | `write_generator`        | `bool`       | Whether to include the generator information                        |
 | `generator`              | `str`        | mpvQC version string (e.g., "mpvQC 0.9.0")                          |
 | &nbsp;                   |              |                                                                     |
@@ -48,6 +53,7 @@ In addition to standard Jinja expressions, mpvQC provides the following properti
 | **Comments**             |              |                                                                     |
 | `comments`               | `list[dict]` | List of comment dictionaries containing:                            |
 |                          |              | • `time` (int): Time in seconds                                     |
+|                          |              | • `time_ms` (int): Time in milliseconds                             |
 |                          |              | • `commentType` (str): Type of comment                              |
 |                          |              | • `comment` (str): The comment text                                 |
 
@@ -56,11 +62,12 @@ In addition to standard Jinja expressions, mpvQC provides the following properti
 | Filter            | Purpose                                    | Usage                                                                   |
 |-------------------|--------------------------------------------|-------------------------------------------------------------------------|
 | `as_time`         | Converts seconds to `HH:mm:ss` format      | `{{ comment['time'] \| as_time }}` → `00:00:00`                         |
+| `as_time_ms`      | Converts milliseconds to `HH:mm:ss.zzz`    | `{{ comment['time_ms'] \| as_time_ms }}` → `00:15:29.340`               |
 | `as_comment_type` | Translates comment type to user's language | `{{ comment['commentType'] \| as_comment_type }}` → Localized type name |
 
-## Default Template
+## Example: The Classic Template
 
-mpvQC uses this template internally for saving QC documents:
+mpvQC uses this template internally for the built-in **mpvQC Classic** export:
 
 ```
 [FILE]

--- a/content/export-templates.md
+++ b/content/export-templates.md
@@ -27,36 +27,59 @@ Once loaded, your custom template appears as a new entry under **File → Export
 
 In addition to standard Jinja expressions, mpvQC provides the following properties and filters:
 
-### Properties
+{{< card >}}
+### Report Metadata
 
-|                          |              |                                                                     |
-|--------------------------|--------------|---------------------------------------------------------------------|
-| **Report Metadata**      |              |                                                                     |
-| `write_date`             | `bool`       | Whether to include the export date/time                             |
-| `date`                   | `str`        | Current date/time as `yyyy-MM-dd HH:mm`                             |
-| `write_generator`        | `bool`       | Whether to include the generator information                        |
-| `generator`              | `str`        | mpvQC version string (e.g., "mpvQC 0.9.0")                          |
-| &nbsp;                   |              |                                                                     |
-| **Video Information**    |              |                                                                     |
-| `write_video_path`       | `bool`       | Whether to include the video file path                              |
-| `video_path`             | `str`        | Absolute path to the video file (empty if no video loaded)          |
-| `video_name`             | `str`        | Video filename with extension (empty if no video loaded)            |
-| &nbsp;                   |              |                                                                     |
-| **User Information**     |              |                                                                     |
-| `write_nickname`         | `bool`       | Whether to include the user's nickname                              |
-| `nickname`               | `str`        | User's nickname for report attribution                              |
-| &nbsp;                   |              |                                                                     |
-| **Subtitle Information** |              |                                                                     |
-| `write_subtitle_paths`   | `bool`       | Whether to include manually imported subtitle paths                 |
-| `subtitles`              | `list[str]`  | List of subtitle file paths                                         |
-| &nbsp;                   |              |                                                                     |
-| **Comments**             |              |                                                                     |
-| `comments`               | `list[dict]` | List of comment dictionaries containing:                            |
-|                          |              | • `time` (int): Time in seconds                                     |
-|                          |              | • `time_ms` (int): Time in milliseconds                             |
-|                          |              | • `commentType` (str): Type of comment                              |
-|                          |              | • `comment` (str): The comment text                                 |
+| Property          | Type   | Description                                  |
+|-------------------|--------|----------------------------------------------|
+| `write_date`      | `bool` | Whether to include the export date/time      |
+| `date`            | `str`  | Current date/time as `yyyy-MM-dd HH:mm`      |
+| `write_generator` | `bool` | Whether to include the generator information |
+| `generator`       | `str`  | mpvQC version string (e.g., "mpvQC 0.9.0")   |
+{{< /card >}}
 
+{{< card >}}
+### Video
+
+| Property           | Type   | Description                                                |
+|--------------------|--------|------------------------------------------------------------|
+| `write_video_path` | `bool` | Whether to include the video file path                     |
+| `video_path`       | `str`  | Absolute path to the video file (empty if no video loaded) |
+| `video_name`       | `str`  | Video filename with extension (empty if no video loaded)   |
+{{< /card >}}
+
+{{< card >}}
+### User
+
+| Property         | Type   | Description                            |
+|------------------|--------|----------------------------------------|
+| `write_nickname` | `bool` | Whether to include the user's nickname |
+| `nickname`       | `str`  | User's nickname for report attribution |
+{{< /card >}}
+
+{{< card >}}
+### Subtitles
+
+| Property               | Type        | Description                                          |
+|------------------------|-------------|------------------------------------------------------|
+| `write_subtitle_paths` | `bool`      | Whether to include manually imported subtitle paths  |
+| `subtitles`            | `list[str]` | List of subtitle file paths                           |
+{{< /card >}}
+
+{{< card >}}
+### Comments
+
+`comments` is a list of dictionaries, one per comment:
+
+| Key           | Type  | Description          |
+|---------------|-------|----------------------|
+| `time`        | `int` | Time in seconds      |
+| `time_ms`     | `int` | Time in milliseconds |
+| `commentType` | `str` | Type of comment      |
+| `comment`     | `str` | The comment text     |
+{{< /card >}}
+
+{{< card >}}
 ### Filters
 
 | Filter            | Purpose                                    | Usage                                                                   |
@@ -64,6 +87,7 @@ In addition to standard Jinja expressions, mpvQC provides the following properti
 | `as_time`         | Converts seconds to `HH:mm:ss` format      | `{{ comment['time'] \| as_time }}` → `00:00:00`                         |
 | `as_time_ms`      | Converts milliseconds to `HH:mm:ss.zzz`    | `{{ comment['time_ms'] \| as_time_ms }}` → `00:15:29.340`               |
 | `as_comment_type` | Translates comment type to user's language | `{{ comment['commentType'] \| as_comment_type }}` → Localized type name |
+{{< /card >}}
 
 ## Example: The Classic Template
 

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -20,6 +20,7 @@
         --code-text-color: #222;
         --blockquote-border-color: #666;
         --blockquote-text-color: #666;
+        --card-border-color: #ddd;
     }
 
     @media (prefers-color-scheme: dark) {
@@ -37,6 +38,7 @@
             --code-text-color: #ddd;
             --blockquote-border-color: #ccc;
             --blockquote-text-color: #ccc;
+            --card-border-color: #999;
         }
     }
 
@@ -157,5 +159,22 @@
     ul li:has(input) {
         list-style-type: none;
         margin-left: -25.5px;
+    }
+
+    .card {
+        box-sizing: border-box;
+        border: 1px solid var(--card-border-color);
+        border-radius: 12px;
+        padding: 0.25rem 1.25rem 1rem;
+    }
+
+    .content-card + .content-card {
+        margin-top: 1rem;
+    }
+
+    .card th,
+    .card td {
+        padding: 6px 16px 6px 0;
+        text-align: left;
     }
 </style>

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -1,0 +1,3 @@
+<div class="card content-card">
+    {{ .Page.RenderString (dict "display" "block") (strings.TrimSpace .Inner) }}
+</div>

--- a/layouts/shortcodes/install-instructions.html
+++ b/layouts/shortcodes/install-instructions.html
@@ -1,23 +1,12 @@
 <style>
     .install-container {
-        --card-border-color: #ddd;
         display: flex;
         flex-wrap: wrap;
         gap: 1rem;
     }
 
-    @media (prefers-color-scheme: dark) {
-        .install-container {
-            --card-border-color: #999;
-        }
-    }
-
     .install-card {
         flex: 1 1 260px;
-        box-sizing: border-box;
-        border: 1px solid var(--card-border-color);
-        border-radius: 8px;
-        padding: 0.25rem 1.25rem 1rem;
     }
 
     .install-card h3 {
@@ -40,7 +29,7 @@
     }
 </style>
 <div class="install-container">
-    <div class="install-card">
+    <div class="install-card card">
         <h3>
             <picture>
                 <!-- https://www.svgrepo.com/svg/232490/windows-operating-system -->
@@ -61,7 +50,7 @@
             <li>Double-click on <b>mpvQC.exe</b> to run it.</li>
         </ol>
     </div>
-    <div class="install-card">
+    <div class="install-card card">
         <h3>
             <picture>
                 <!-- https://www.svgrepo.com/svg/232488/linux-->

--- a/static/api/v1/public/version
+++ b/static/api/v1/public/version
@@ -1,1 +1,1 @@
-{"latest": "0.9.0-beta4"}
+{"latest": "0.9.0-beta5"}


### PR DESCRIPTION
Goes live with the 0.9.0-beta5 release:

- Updates the export-templates page for the JSON document format: routes tooling authors to the schema, documents `time_ms` and `as_time_ms`, and attributes the built-in template to the classic export
- Presents the template reference as cards, sharing one card style with the installation section
- Bumps the version endpoint so the in-app update check reports 0.9.0-beta5

Merge on release day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)